### PR TITLE
fix docker CMD to point to correct file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ COPY . .
 RUN npm run build
 
 EXPOSE 3000
-CMD ["node", "server.js"]
+CMD ["node", "functions/server.js"]
 
 USER node


### PR DESCRIPTION
When trying to use the docker image, my container was in a crash loop with the following error:
```
Error: Cannot find module '/usr/src/app/server.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:815:15)
    at Function.Module._load (internal/modules/cjs/loader.js:667:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
internal/modules/cjs/loader.js:818
  throw err;
  ^```

This branch changes the Dockerfile node command to run `functions/server.js` instead of `server.js`.  Locally this fixed my issue and I was able to run the docker image properly.